### PR TITLE
Point Tools nav item to AI Security Solutions Landscape

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1056,7 +1056,7 @@ input, select { font-family: inherit; }
       <a href="#/frameworks">Frameworks</a>
       <a href="#/crosswalk">Crosswalk</a>
       <a href="#/incidents">Incidents</a>
-      <a href="#/tools">Tools</a>
+      <a href="https://genai.owasp.org/ai-security-solutions-landscape/" target="_blank" rel="noopener">Tools</a>
       <a href="#/recipes">Recipes</a>
       <a href="#/glossary">Glossary</a>
       <a href="#/score">Score</a>
@@ -1086,7 +1086,7 @@ input, select { font-family: inherit; }
   <a href="#/frameworks">Frameworks</a>
   <a href="#/crosswalk">Crosswalk</a>
   <a href="#/incidents">Incidents</a>
-  <a href="#/tools">Tools</a>
+  <a href="https://genai.owasp.org/ai-security-solutions-landscape/" target="_blank" rel="noopener">Tools</a>
   <a href="#/recipes">Recipes</a>
   <a href="#/glossary">Glossary</a>
   <a href="#/score">Score</a>


### PR DESCRIPTION
## Summary
- Updates the "Tools" nav link (desktop + mobile menus) from the in-app `#/tools` route to the external OWASP GenAI Security Project page: https://genai.owasp.org/ai-security-solutions-landscape/
- Opens in a new tab (`target="_blank" rel="noopener"`), consistent with the existing GitHub icon link in the nav

## Test plan
- [x] Served `docs/` locally, confirmed both nav instances render the updated `href` and `target="_blank"`
- [x] Screenshot of nav bar shows no visual/layout change