### PR TITLE
fix(DATA-01): make stats:check line-ending agnostic

### DIFF
--- a/scripts/render-stats.mjs
+++ b/scripts/render-stats.mjs
@@ -82,7 +82,14 @@ function render(src) {
   return { out, seen, unknown };
 }
 
-const before = fs.readFileSync(README, 'utf8');
+/**
+ * LF-normalise on read. With core.autocrlf=true a Windows checkout is CRLF while
+ * the rendered badge block is emitted with LF — writing that back would leave the
+ * file with mixed line endings, and comparing raw would report every Windows
+ * working copy as stale. The repo is LF-canonical in the index either way, so all
+ * work happens in LF and git converts on checkout.
+ */
+const before = fs.readFileSync(README, 'utf8').replace(/\r\n/g, '\n');
 const { out, seen, unknown } = render(before);
 
 if (unknown.length) {

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -43,6 +43,9 @@ const SOURCE_LISTS = [
   { id: 'DSGAI-2026', label: 'DSGAI 2026', dir: 'dsgai-2026' },
 ];
 
+/** LF-normalise so comparisons are content-based, not checkout-dependent. */
+const normalizeEol = (s) => s.replace(/\r\n/g, '\n');
+
 const readJson = (p) => JSON.parse(fs.readFileSync(p, 'utf8'));
 const jsonFiles = (dir) =>
   fs.readdirSync(dir).filter((f) => f.endsWith('.json')).map((f) => path.join(dir, f));
@@ -130,7 +133,10 @@ function main() {
 
   if (CHECK) {
     const current = fs.existsSync(OUT) ? fs.readFileSync(OUT, 'utf8') : '';
-    if (current !== text) {
+    // Compare content, not line endings. With core.autocrlf=true the checked-out
+    // file is CRLF while this script emits LF, which would report every Windows
+    // working copy as stale even when nothing changed.
+    if (normalizeEol(current) !== normalizeEol(text)) {
       console.error('✗ data/stats.json is stale — run `npm run stats`');
       process.exit(1);
     }


### PR DESCRIPTION
Follow-up to #6.

`npm run stats:check` passed in CI and failed on every Windows checkout. With `core.autocrlf=true` the working copy is CRLF while the scripts emit LF, so the raw text comparison reported "stale" on a tree whose content was byte-identical. CI runs on Linux, which hid it.

Both `--check` paths now compare LF-normalised content. `render-stats.mjs` also normalises on read — it emits the badge block with LF, so writing back to a CRLF working copy would have left README.md with mixed line endings.

**Verify** (on a CRLF working copy):

| Case | Exit |
|---|---|
| clean tree | 0 |
| planted drift in `data/stats.json` | 1 |
| planted drift in `README.md` markers | 1 |

Baseline: 0 err / 67 warn, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)