### PR TITLE
fix(ATTR-02): clone instructions point at the OWASP repo, not the personal one

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Pick your risk, find your controls.
 **3. Run the tools** (for security engineers and red-teamers)
 
 ```bash
-git clone https://github.com/emmanuelgjr/GenAI-Security-Crosswalk.git
-cd GenAI-Security-Crosswalk
+git clone https://github.com/GenAI-Security-Project/crosswalk.git
+cd crosswalk
 node scripts/compliance-report.js --framework "EU AI Act"   # gap assessment
 node scripts/incidents-report.js --entry LLM01              # incident analysis
 node scripts/compliance-report.js --format oscal            # GRC platform export
@@ -225,7 +225,7 @@ All free. All open-source. Built for practitioners.
 ## Repository structure
 
 ```text
-GenAI-Security-Crosswalk/
+crosswalk/
 │
 ├── README.md
 ├── CROSSREF.md                      ← Master cross-reference: LLM ↔ ASI ↔ DSGAI


### PR DESCRIPTION
Follow-up to #12.

## The webapp is already correct — the stale one is a different site

I checked what is actually being served:

| Deployment | `2025` hits | State |
|---|--:|---|
| `genai-security-project.github.io/crosswalk/` | 2 | **current** — both are historical timeline rows |
| `emmanuelgjr.github.io/GenAI-Security-Crosswalk/` | 13 | **stale** — `LLM-Top10-2025`, old entry names |

Verified the live OWASP bundle directly: 41 entries, source lists `LLM-Top10-2026 / Agentic-Top10-2026 / DSGAI-2026`, `LLM03 Excessive Agency`, `LLM08 Hidden Context Exposure`, `LLM10 Improper Output Handling`, and every changelog author reading *OWASP GenAI Data Security Initiative*.

## What this PR fixes

README still told readers to `git clone emmanuelgjr/GenAI-Security-Crosswalk` and `cd` into it, and the repo tree diagram used that as its root. Both now name `GenAI-Security-Project/crosswalk`.

That was sending people to stale code, not just the wrong name.

## 🚩 Two things I cannot fix from this repo

1. **The stale Pages deployment.** `emmanuelgjr/GenAI-Security-Crosswalk` is a **separate public repository**, last pushed 2026-08-24, not archived. Its Pages site keeps serving the pre-migration webapp. Archiving it, updating it, or redirecting it is a call on that repo.
2. **Clone instructions can't work publicly.** `GenAI-Security-Project/crosswalk` is **private**, so the corrected clone command fails for anyone outside the org. The URL is right; the visibility is a separate decision.

Also worth a look: `package.json` `repository`/`bugs`/`homepage` point at `GenAI-Security-Project/GenAI-Data-Security-Initiative` (public, resolves 200) rather than this repo. Left alone — it may be the intended umbrella project.

**Verify:** validate 0 errors / 281 passed · stats:check green · markdownlint 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)