### PR TITLE
T-A10-04: Universal Skill Format reference + AST in the webapp

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1355,7 +1355,8 @@ input, select { font-family: inherit; }
   var SOURCE_LABELS = {
     'LLM-Top10-2026': 'LLM Top 10 2026',
     'Agentic-Top10-2026': 'Agentic Top 10 2026',
-    'DSGAI-2026': 'DSGAI 2026'
+    'DSGAI-2026': 'DSGAI 2026',
+    'AST-Top10-2026': 'Agentic Skills Top 10'
   };
 
   // Placeholder entries — replace with real submissions
@@ -1854,7 +1855,8 @@ input, select { font-family: inherit; }
     var sourceGroups = [
       { key: 'LLM-Top10-2026', name: 'LLM Top 10 2026', prefix: 'LLM' },
       { key: 'Agentic-Top10-2026', name: 'Agentic Top 10 2026', prefix: 'ASI' },
-      { key: 'DSGAI-2026', name: 'DSGAI 2026', prefix: 'DSGAI' }
+      { key: 'DSGAI-2026', name: 'DSGAI 2026', prefix: 'DSGAI' },
+      { key: 'AST-Top10-2026', name: 'Agentic Skills Top 10', prefix: 'AST' }
     ];
 
     sourceGroups.forEach(function(sg) {
@@ -1959,7 +1961,7 @@ input, select { font-family: inherit; }
 
     // Source pills
     var srcGroup = el('div', { className: 'pill-group' });
-    [['All', ''], ['LLM', 'LLM-Top10-2026'], ['Agentic', 'Agentic-Top10-2026'], ['DSGAI', 'DSGAI-2026']].forEach(function(item) {
+    [['All', ''], ['LLM', 'LLM-Top10-2026'], ['Agentic', 'Agentic-Top10-2026'], ['DSGAI', 'DSGAI-2026'], ['Skills', 'AST-Top10-2026']].forEach(function(item) {
       var p = el('button', {
         className: 'pill' + (item[0] === 'All' ? ' active' : ''),
         'aria-label': 'Filter by ' + item[0] + ' source list'
@@ -2246,6 +2248,12 @@ input, select { font-family: inherit; }
   // ══════════════════════════════════════════════════════════════════════════════
   function renderFrameworks(container) {
     // Build framework data
+    // Entries with no mappings at all cannot be covered by any framework, so
+    // they are excluded from the coverage denominator. Counting them would
+    // deflate every framework's percentage by the size of an unmapped source
+    // list (see ast-top10/README.md).
+    var MAPPABLE = DATA.filter(function(e) { return e.mappings.length > 0; }).length;
+
     var fwData = FRAMEWORKS.map(function(fw) {
       var entries = DATA.filter(function(e) { return e.mappings.some(function(m) { return m.framework === fw; }); });
       var totalControls = 0;
@@ -2253,13 +2261,14 @@ input, select { font-family: inherit; }
       var llm = entries.filter(function(e) { return e.source_list === 'LLM-Top10-2026'; }).length;
       var asi = entries.filter(function(e) { return e.source_list === 'Agentic-Top10-2026'; }).length;
       var dsg = entries.filter(function(e) { return e.source_list === 'DSGAI-2026'; }).length;
-      var covLevel = Math.round(entries.length / DATA.length * 100) >= 90 ? 'High' : Math.round(entries.length / DATA.length * 100) >= 70 ? 'Medium' : 'Low';
+      var covPct = MAPPABLE > 0 ? Math.round(entries.length / MAPPABLE * 100) : 0;
+      var covLevel = covPct >= 90 ? 'High' : covPct >= 70 ? 'Medium' : 'Low';
       // Collect unique source lists
       var srcLists = [];
       if (llm > 0) srcLists.push('LLM');
       if (asi > 0) srcLists.push('Agentic');
       if (dsg > 0) srcLists.push('DSGAI');
-      return { name: fw, entries: entries.length, controls: totalControls, pct: Math.round(entries.length / DATA.length * 100), llm: llm, asi: asi, dsg: dsg, covLevel: covLevel, srcLists: srcLists };
+      return { name: fw, entries: entries.length, controls: totalControls, pct: covPct, llm: llm, asi: asi, dsg: dsg, covLevel: covLevel, srcLists: srcLists };
     }).sort(function(a, b) { return b.entries - a.entries; });
 
     var totalMapped = 0;
@@ -3325,7 +3334,8 @@ input, select { font-family: inherit; }
   var CW_OWASP_COLOR = {
     'LLM-Top10-2026': '#dc2626',
     'Agentic-Top10-2026': '#7c3aed',
-    'DSGAI-2026': '#0891b2'
+    'DSGAI-2026': '#0891b2',
+    'AST-Top10-2026': '#7c3aed'
   };
   function cwColorFor(framework, colorMap) {
     if (CW_OWASP_COLOR[framework]) return CW_OWASP_COLOR[framework];
@@ -3389,7 +3399,8 @@ input, select { font-family: inherit; }
   var CW_SOURCE_META = {
     'LLM-Top10-2026': { label: 'LLM Top 10', sub: '2026' },
     'Agentic-Top10-2026': { label: 'Agentic Top 10', sub: '2026' },
-    'DSGAI-2026': { label: 'DSGAI', sub: '2026' }
+    'DSGAI-2026': { label: 'DSGAI', sub: '2026' },
+    'AST-Top10-2026': { label: 'Agentic Skills', sub: '2026' }
   };
 
   function renderCrosswalk(container) {
@@ -3534,6 +3545,7 @@ input, select { font-family: inherit; }
       { id: 'LLM-Top10-2026', label: 'LLM Top 10' },
       { id: 'Agentic-Top10-2026', label: 'Agentic Top 10' },
       { id: 'DSGAI-2026', label: 'DSGAI' },
+      { id: 'AST-Top10-2026', label: 'Agentic Skills' },
       { id: 'risks', label: 'Risks only' },
       { id: 'frameworks', label: 'Frameworks only' }
     ];
@@ -4261,7 +4273,8 @@ input, select { font-family: inherit; }
     var SOURCE_GROUPS = [
       { label: 'LLM Top 10', prefix: 'LLM', list: 'LLM-Top10-2026' },
       { label: 'Agentic Top 10', prefix: 'ASI', list: 'Agentic-Top10-2026' },
-      { label: 'DSGAI 2026', prefix: 'DSGAI', list: 'DSGAI-2026' }
+      { label: 'DSGAI 2026', prefix: 'DSGAI', list: 'DSGAI-2026' },
+      { label: 'Agentic Skills Top 10', prefix: 'AST', list: 'AST-Top10-2026' }
     ];
 
     function computeGaps() {
@@ -4292,7 +4305,7 @@ input, select { font-family: inherit; }
       // Sort: group by source_list, then status (none first), then severity
       var sevOrder = { Critical: 0, High: 1, Medium: 2, Low: 3 };
       var statusOrder = { none: 0, partial: 1, full: 2 };
-      var sourceOrder = { 'LLM-Top10-2026': 0, 'Agentic-Top10-2026': 1, 'DSGAI-2026': 2 };
+      var sourceOrder = { 'LLM-Top10-2026': 0, 'Agentic-Top10-2026': 1, 'DSGAI-2026': 2, 'AST-Top10-2026': 3 };
       results.sort(function(a, b) {
         var s = (sourceOrder[a.source_list] || 9) - (sourceOrder[b.source_list] || 9);
         if (s !== 0) return s;
@@ -4824,7 +4837,7 @@ input, select { font-family: inherit; }
       var overallPct = totalWeight > 0 ? Math.round((weightedScore / totalWeight) * 100) : 0;
 
       // Per source list
-      var sourceLists = ['LLM-Top10-2026', 'Agentic-Top10-2026', 'DSGAI-2026'];
+      var sourceLists = ['LLM-Top10-2026', 'Agentic-Top10-2026', 'DSGAI-2026', 'AST-Top10-2026'];
       var sourceStats = {};
       sourceLists.forEach(function(sl) {
         var slEntries = entryScores.filter(function(es) { return es.entry.source_list === sl; });

--- a/shared/UNIVERSAL_SKILL_FORMAT.md
+++ b/shared/UNIVERSAL_SKILL_FORMAT.md
@@ -1,0 +1,92 @@
+<!--
+  OWASP GenAI Crosswalk
+  File    : shared/UNIVERSAL_SKILL_FORMAT.md
+  Purpose : The AST10 Universal Skill Format, cross-linked to the risks it mitigates
+  Version : 2026-Q3
+  License : CC BY-SA 4.0
+-->
+
+# Universal Agentic Skill Format
+
+The OWASP Agentic Skills Top 10 proposes a **Universal Agentic Skill Format**: a
+signed, declarative manifest describing what a skill may do, so that a claim
+about a skill's behaviour can be checked rather than trusted.
+
+This note summarises the format and cross-links each feature to the `AST` risk it
+addresses. It is a **reference, not a specification** — the format is defined by
+the AST10 project and the authoritative version is theirs:
+
+> <https://owasp.org/www-project-agentic-skills-top-10/>
+>
+> **Attribution.** The Universal Agentic Skill Format is the work of the OWASP
+> Agentic Skills Top 10 project, a sibling OWASP project with its own leads and
+> contributors. It is described here because the crosswalk maps its risks, not
+> because it originates here.
+
+---
+
+## Why a manifest at all
+
+The skill layer sits between the model and its tools. MCP defines *what* tools
+exist; a skill file defines *how* an agent orchestrates them. That file is
+executable configuration, it frequently comes from a third party, and it has
+historically received none of the review any other dependency would get.
+
+A manifest turns implicit behaviour into a declaration that can be signed,
+diffed, scanned and enforced — which is what makes each of the mitigations below
+possible.
+
+## Format features, and the risks they address
+
+| Feature | What it does | Addresses |
+|---|---|---|
+| `signature` (ed25519) | signs the canonical hash of the manifest | [AST01](../CROSSREF.md) Malicious Skills · AST02 Supply Chain Compromise |
+| `content_hash` (sha256) | hash of the complete skill package | AST01 · AST02 · AST07 Update Drift |
+| `permissions` allow/deny lists | explicit paths, no wildcards | AST03 Over-Privileged Skills |
+| `permissions.deny_write` | protects identity files — `SOUL.md`, `MEMORY.md`, `AGENTS.md` | AST03 · AST05 Untrusted External Instructions |
+| `network.allow` domain allowlist | egress by domain, not a binary on/off, with `deny: "*"` default | AST03 · AST05 |
+| `requires` | declared binaries and `min_runtime_version` | AST02 · AST07 |
+| `risk_tier` (L0–L3) | L0 safe → L3 destructive; a declared blast radius | AST09 No Governance · AST10 Cross-Platform Reuse |
+| `scan_status` | scanner identity, last-scanned date, result | AST08 Poor Scanning |
+| `changelog` | versioned history of the manifest itself | AST07 · AST09 |
+
+### The identity-file carve-out is the interesting one
+
+`permissions.deny_write` names `SOUL.md`, `MEMORY.md` and `AGENTS.md` explicitly.
+Those files define who the agent believes it is and what it remembers. A skill
+that can rewrite them does not merely act beyond its remit — it changes the
+agent's future behaviour in every later session. Requiring an explicit grant to
+touch them treats agent identity as a protected resource rather than as ordinary
+state, which is the same instinct behind
+[LLM08 Hidden Context Exposure](../llm-top10/LLM_MITREATLAS.md) and
+[ASI06 Memory & Context Poisoning](../agentic-top10/Agentic_MITREATLAS.md).
+
+### `risk_tier` is a governance primitive
+
+L0–L3 is not a severity score. It is a declaration of what a skill is *permitted*
+to be, which lets an organisation set policy — "no L3 skills outside the sandbox
+tier" — without reading every manifest. That is what makes AST09 (No Governance)
+and AST10 (Cross-Platform Reuse) tractable at fleet scale.
+
+## Relationship to the crosswalk's own mappings
+
+The format is a **mitigation**, not a framework. It does not appear in
+`data/frameworks/`, and it is not something the crosswalk maps risks *to*.
+
+Where a control in a mapped framework requires the property this format
+provides — artifact signing, least-privilege manifests, egress allowlisting,
+inventory — the mapping lives in the `ast-top10/` files. Those are **not yet
+authored**: risk-to-control mapping is expert work, tracked as T-A10-03.
+
+## Status
+
+| | |
+|---|---|
+| Format | proposed by the AST10 project |
+| Included here as | reference and cross-link |
+| AST risk mappings | not yet authored — see [`ast-top10/README.md`](../ast-top10/README.md) |
+
+---
+
+*Part of the [OWASP GenAI Crosswalk](https://github.com/GenAI-Security-Project/crosswalk) —
+maintained by the [OWASP GenAI Data Security Initiative](https://genai.owasp.org)*


### PR DESCRIPTION
## What

Two things, both downstream of registering the Agentic Skills Top 10 as a fourth source list.

**`shared/UNIVERSAL_SKILL_FORMAT.md`** — a reference note on the AST10 project's Universal Agentic Skill Format, cross-linking each manifest feature to the `AST` risk it addresses:

| Feature | Addresses |
|---|---|
| `signature`, `content_hash` | AST01 Malicious Skills · AST02 Supply Chain Compromise |
| `permissions` allow/deny, `deny_write` | AST03 Over-Privileged Skills · AST05 Untrusted External Instructions |
| `network.allow` | AST03 · AST05 |
| `requires` | AST02 · AST07 Update Drift |
| `risk_tier` (L0–L3) | AST09 No Governance · AST10 Cross-Platform Reuse |
| `scan_status` | AST08 Poor Scanning |

It is a **reference, not a specification**. The format belongs to the Agentic Skills Top 10 project — a sibling OWASP project with its own leads — and the file says so in its own attribution block.

**Webapp (`docs/index.html`)** — two changes:

1. Registers the nine AST source-list entries, so AST01–AST10 appear in the source filter alongside LLM, ASI and DSGAI.
2. **Fixes the framework coverage denominator.** Coverage was measured against every entry. Registering ten entries that carry no mappings yet would have silently deflated every framework from 100% to 80% — a real-looking regression caused entirely by adding a source list. Entries with no mappings cannot be covered by any framework, so they are now excluded from the denominator.

   Verified: MITRE ATLAS `old pct: 80% (deflated)` → `new pct: 100% (correct)`.

## What this does not do

No mapping content is authored. AST risk-to-control mapping is expert work under C4 and stays with **T-A10-03**; the ten AST entries ship with `mappings: []` and say so.

## Verification

- `validate.js` — 0 errors, 69 warnings, 283 passed
- `stats:check` — `data/stats.json` current, README current (10 marker keys)
- `markdownlint-cli2` — 0 errors
- `test:scripts` — 3 pass, 0 fail
- `tsc` — clean
- Webapp inline JS syntax-checked; C2 structural check: tags/functions 90→90, routes 11→11, 0 logo/css files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)