### PR TITLE
CI: run the generator and assert its output matches what is committed

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,22 +7,26 @@ on:
       - 'llm-top10/**'
       - 'agentic-top10/**'
       - 'dsgai-2026/**'
+      - 'ast-top10/**'
       - 'shared/**'
       - 'data/**'
       - 'CROSSREF.md'
       - 'README.md'
       - 'scripts/validate.js'
+      - 'scripts/generate.js'
   pull_request:
     branches: [main]
     paths:
       - 'llm-top10/**'
       - 'agentic-top10/**'
       - 'dsgai-2026/**'
+      - 'ast-top10/**'
       - 'shared/**'
       - 'data/**'
       - 'CROSSREF.md'
       - 'README.md'
       - 'scripts/validate.js'
+      - 'scripts/generate.js'
 
 # Both jobs only read the tree. Without this they inherit the repository
 # default, which is write.
@@ -80,3 +84,29 @@ jobs:
       # git must agree that nothing moved.
       - name: Assert no uncommitted drift
         run: git diff --exit-code -- README.md data/stats.json
+
+  generator:
+    name: Generator reproducibility
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Use Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+
+      # generate.js sat broken on main for several commits: a migration script
+      # was run more than once and left three `const AST_IDS` declarations, so
+      # the file threw a SyntaxError on load. Nothing noticed, because no job
+      # ran it. This one does.
+      - name: Run the generator
+        run: node scripts/generate.js
+
+      # And its output must match what is committed, so a hand-edit to a
+      # generated file, or a source change that was never regenerated, fails
+      # here rather than shipping.
+      - name: Assert generated output is current
+        run: git diff --exit-code -- data/entries docs/data.js docs/incidents.js

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,6 +14,7 @@ on:
       - 'README.md'
       - 'scripts/validate.js'
       - 'scripts/generate.js'
+      - '.github/workflows/validate.yml'
   pull_request:
     branches: [main]
     paths:
@@ -27,6 +28,7 @@ on:
       - 'README.md'
       - 'scripts/validate.js'
       - 'scripts/generate.js'
+      - '.github/workflows/validate.yml'
 
 # Both jobs only read the tree. Without this they inherit the repository
 # default, which is write.


### PR DESCRIPTION
## Why

`generate.js` sat broken on `main` for several commits (fixed in #28) and nothing caught it — because **no job ran it**. The Content Validation workflow runs `validate.js` and `stats:check`, neither of which loads the generator. A file that produces every entry in `data/entries/` and both webapp data bundles had no CI coverage at all.

## What

A **Generator reproducibility** job that runs `node scripts/generate.js` and then asserts:

```
git diff --exit-code -- data/entries docs/data.js docs/incidents.js
```

That catches three failures the existing jobs cannot:

1. the generator failing to load or throw at all (the #28 case);
2. a hand-edit to a generated file, which would be silently overwritten on the next run;
3. a source change that was never regenerated, so `data/entries/` and the webapp disagree with the Markdown.

## Also

The path filters still listed three source directories. Nothing under `ast-top10/` triggered validation, and a change to `scripts/generate.js` itself triggered nothing. Both are added.

## Verification

Run locally against the current tree: generator runs clean, `git diff --exit-code` over those paths is empty — the guard passes on `main` as it stands, so it gates future drift rather than flagging existing state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)