### PR TITLE
Fix: MAESTRO layer names contradicted the CSA source and our own mapping files

### DIFF
--- a/data/frameworks/maestro.json
+++ b/data/frameworks/maestro.json
@@ -12,7 +12,7 @@
   "controls": [
     {
       "control_id": "L1",
-      "title": "Foundation Models Layer",
+      "title": "Foundation Models",
       "description": "Base model layer — covers model selection, provenance, fine-tuning security, and model integrity threats.",
       "parent": null,
       "function": "Architecture Layer",
@@ -44,7 +44,7 @@
     },
     {
       "control_id": "L2",
-      "title": "Data Operations Layer",
+      "title": "Data Operations",
       "description": "Data pipelines — covers RAG, vector stores, training data, embedding security, and data governance.",
       "parent": null,
       "function": "Architecture Layer",
@@ -76,7 +76,7 @@
     },
     {
       "control_id": "L3",
-      "title": "Agent Frameworks Layer",
+      "title": "Agent Frameworks",
       "description": "Agent runtime — covers agent orchestration, goal management, memory, and planning security.",
       "parent": null,
       "function": "Architecture Layer",
@@ -108,7 +108,7 @@
     },
     {
       "control_id": "L4",
-      "title": "Tools and Integration Layer",
+      "title": "Deployment & Infrastructure",
       "description": "Tool access — covers MCP, API integrations, plugin security, and tool authorization.",
       "parent": null,
       "function": "Architecture Layer",
@@ -140,7 +140,7 @@
     },
     {
       "control_id": "L5",
-      "title": "Deployment Infrastructure Layer",
+      "title": "Evaluation & Observability",
       "description": "Infrastructure — covers containerization, networking, secrets management, and runtime isolation.",
       "parent": null,
       "function": "Architecture Layer",
@@ -172,7 +172,7 @@
     },
     {
       "control_id": "L6",
-      "title": "Orchestration Layer",
+      "title": "Security & Compliance",
       "description": "Multi-agent coordination — covers inter-agent communication, delegation, consensus, and cascading failure prevention.",
       "parent": null,
       "function": "Architecture Layer",
@@ -204,7 +204,7 @@
     },
     {
       "control_id": "L7",
-      "title": "Interaction and User Interface Layer",
+      "title": "Agent Ecosystem",
       "description": "Human-agent interface — covers user authentication, output validation, human oversight, and trust management.",
       "parent": null,
       "function": "Architecture Layer",

--- a/data/incidents.json
+++ b/data/incidents.json
@@ -2628,7 +2628,7 @@
       "maestro_layers": [
         {
           "layer": "L7",
-          "label": "Multi-Agent Ecosystem",
+          "label": "Agent Ecosystem",
           "role": "origin",
           "notes": "Multi-agent ecosystem with no inter-agent consistency validation"
         },
@@ -3030,7 +3030,7 @@
         },
         {
           "layer": "L7",
-          "label": "Ecosystem",
+          "label": "Agent Ecosystem",
           "role": "impact",
           "notes": "Self-replication attempts threaten agent ecosystem integrity"
         }
@@ -6915,22 +6915,22 @@
       ],
       "maestro_layers": [
         {
-          "layer": "L4",
-          "label": "Tools and Integration Layer",
+          "layer": "L7",
+          "label": "Agent Ecosystem",
           "role": "origin",
-          "notes": "Skill registry used as the distribution channel"
+          "notes": "Registry-scale campaign across the skill ecosystem"
         },
         {
           "layer": "L3",
-          "label": "Agent Frameworks Layer",
+          "label": "Agent Frameworks",
           "role": "propagation",
           "notes": "Instructions written into MEMORY.md and SOUL.md persist across sessions"
         },
         {
-          "layer": "L5",
-          "label": "Deployment Infrastructure Layer",
+          "layer": "L6",
+          "label": "Security & Compliance",
           "role": "impact",
-          "notes": "Credential, wallet and .env exfiltration to a single C2 IP"
+          "notes": "Exchange keys, wallet keys, SSH credentials and .env files exfiltrated to a single C2 IP"
         }
       ],
       "attack_vector": "Registry publisher accounts used to distribute skills that exfiltrate credentials and write persistent instructions into agent identity files",
@@ -6964,7 +6964,7 @@
       "control_failures": [
         {
           "framework": "MAESTRO",
-          "control_id": "L3.2",
+          "control_id": "L3",
           "outcome": "absent",
           "basis": "Skills also write malicious instructions directly into MEMORY.md and SOUL.md for session-persistent backdooring.",
           "source_url": "https://owasp.org/www-project-agentic-skills-top-10/",
@@ -7004,14 +7004,14 @@
       ],
       "maestro_layers": [
         {
-          "layer": "L4",
-          "label": "Tools and Integration Layer",
+          "layer": "L3",
+          "label": "Agent Frameworks",
           "role": "origin",
           "notes": "Skill manifest carries the instruction"
         },
         {
-          "layer": "L5",
-          "label": "Deployment Infrastructure Layer",
+          "layer": "L6",
+          "label": "Security & Compliance",
           "role": "impact",
           "notes": "SSH private key exfiltration"
         }
@@ -7064,16 +7064,16 @@
       ],
       "maestro_layers": [
         {
-          "layer": "L4",
-          "label": "Tools and Integration Layer",
+          "layer": "L3",
+          "label": "Agent Frameworks",
           "role": "origin",
           "notes": "Published skills cleared by registry checks"
         },
         {
-          "layer": "L7",
-          "label": "Interaction and User Interface Layer",
+          "layer": "L5",
+          "label": "Evaluation & Observability",
           "role": "blind-spot",
-          "notes": "Detection came from behaviour at runtime, not from review at publication"
+          "notes": "Detection came from runtime behaviour, not from review at publication"
         }
       ],
       "attack_vector": "Malicious skills published to a registry and installed by users before any behavioural signal surfaced",
@@ -7123,14 +7123,14 @@
       ],
       "maestro_layers": [
         {
-          "layer": "L4",
-          "label": "Tools and Integration Layer",
+          "layer": "L7",
+          "label": "Agent Ecosystem",
           "role": "origin",
           "notes": "Ecosystem-wide flaw density in published skills"
         },
         {
-          "layer": "L7",
-          "label": "Interaction and User Interface Layer",
+          "layer": "L5",
+          "label": "Evaluation & Observability",
           "role": "blind-spot",
           "notes": "8 confirmed-malicious skills still live at publication"
         }
@@ -7182,16 +7182,16 @@
       ],
       "maestro_layers": [
         {
-          "layer": "L4",
-          "label": "Tools and Integration Layer",
+          "layer": "L3",
+          "label": "Agent Frameworks",
           "role": "origin",
-          "notes": "Skills request more permission than their function needs"
+          "notes": "Skills declare more permission than their function needs"
         },
         {
-          "layer": "L5",
-          "label": "Deployment Infrastructure Layer",
+          "layer": "L6",
+          "label": "Security & Compliance",
           "role": "impact",
-          "notes": "API key and PII exposure"
+          "notes": "API key and PII exposure through the granted scope"
         }
       ],
       "attack_vector": "Over-broad skill permissions turn ordinary skill execution into credential and PII disclosure",
@@ -7241,14 +7241,14 @@
       ],
       "maestro_layers": [
         {
-          "layer": "L4",
-          "label": "Tools and Integration Layer",
+          "layer": "L3",
+          "label": "Agent Frameworks",
           "role": "origin",
           "notes": "Registry listing metadata impersonates a known brand"
         },
         {
           "layer": "L7",
-          "label": "Interaction and User Interface Layer",
+          "label": "Agent Ecosystem",
           "role": "impact",
           "notes": "User trust decision made on false metadata"
         }
@@ -7301,8 +7301,8 @@
       ],
       "maestro_layers": [
         {
-          "layer": "L4",
-          "label": "Tools and Integration Layer",
+          "layer": "L5",
+          "label": "Evaluation & Observability",
           "role": "blind-spot",
           "notes": "Signature scanning has no signature to match on instruction payloads"
         }
@@ -7353,14 +7353,20 @@
       ],
       "maestro_layers": [
         {
-          "layer": "L5",
-          "label": "Deployment Infrastructure Layer",
+          "layer": "L4",
+          "label": "Deployment & Infrastructure",
           "role": "origin",
-          "notes": "Unauthenticated WebSocket writes reach the log file"
+          "notes": "Unauthenticated WebSocket writes reach the host log file"
+        },
+        {
+          "layer": "L5",
+          "label": "Evaluation & Observability",
+          "role": "propagation",
+          "notes": "The diagnostic log becomes the injection channel"
         },
         {
           "layer": "L3",
-          "label": "Agent Frameworks Layer",
+          "label": "Agent Frameworks",
           "role": "impact",
           "notes": "Agent reads its own logs and acts on injected text"
         }
@@ -7414,22 +7420,22 @@
       ],
       "maestro_layers": [
         {
-          "layer": "L4",
-          "label": "Tools and Integration Layer",
+          "layer": "L3",
+          "label": "Agent Frameworks",
           "role": "origin",
-          "notes": "Repository-controlled configuration files"
+          "notes": "Repository-controlled configuration consumed at project open"
         },
         {
-          "layer": "L7",
-          "label": "Interaction and User Interface Layer",
+          "layer": "L6",
+          "label": "Security & Compliance",
           "role": "blind-spot",
           "notes": "Execution precedes the trust dialog meant to gate it"
         },
         {
-          "layer": "L5",
-          "label": "Deployment Infrastructure Layer",
+          "layer": "L4",
+          "label": "Deployment & Infrastructure",
           "role": "impact",
-          "notes": "Arbitrary shell execution and API key exfiltration"
+          "notes": "Arbitrary shell execution and API key exfiltration on the host"
         }
       ],
       "attack_vector": "Repository configuration files executed at project open time, ahead of the user consent prompt",
@@ -7463,7 +7469,7 @@
       "control_failures": [
         {
           "framework": "MAESTRO",
-          "control_id": "L7.2",
+          "control_id": "L6",
           "outcome": "present-but-bypassed",
           "basis": "Repository-controlled configuration files can silently execute arbitrary shell commands and exfiltrate API keys at project open time, before any trust dialog.",
           "source_url": "https://owasp.org/www-project-agentic-skills-top-10/",
@@ -7501,20 +7507,20 @@
       ],
       "maestro_layers": [
         {
-          "layer": "L5",
-          "label": "Deployment Infrastructure Layer",
+          "layer": "L4",
+          "label": "Deployment & Infrastructure",
           "role": "origin",
           "notes": "Unrate-limited localhost WebSocket reachable from the browser"
         },
         {
           "layer": "L6",
-          "label": "Orchestration Layer",
+          "label": "Security & Compliance",
           "role": "propagation",
           "notes": "Device registration without a user prompt"
         },
         {
-          "layer": "L4",
-          "label": "Tools and Integration Layer",
+          "layer": "L7",
+          "label": "Agent Ecosystem",
           "role": "impact",
           "notes": "Exfiltration through the agent's existing integrations"
         }
@@ -7550,7 +7556,7 @@
       "control_failures": [
         {
           "framework": "MAESTRO",
-          "control_id": "L7.2",
+          "control_id": "L6",
           "outcome": "absent",
           "basis": "Malicious websites can brute-force localhost WebSocket connections with no rate limiting to silently hijack local OpenClaw instances, register new devices without user prompts.",
           "source_url": "https://owasp.org/www-project-agentic-skills-top-10/",
@@ -7589,14 +7595,14 @@
       ],
       "maestro_layers": [
         {
-          "layer": "L5",
-          "label": "Deployment Infrastructure Layer",
+          "layer": "L4",
+          "label": "Deployment & Infrastructure",
           "role": "origin",
           "notes": "Commodity infostealer on the host"
         },
         {
           "layer": "L3",
-          "label": "Agent Frameworks Layer",
+          "label": "Agent Frameworks",
           "role": "impact",
           "notes": "Agent identity and memory files exfiltrated"
         }
@@ -7650,14 +7656,14 @@
       ],
       "maestro_layers": [
         {
-          "layer": "L4",
-          "label": "Tools and Integration Layer",
+          "layer": "L3",
+          "label": "Agent Frameworks",
           "role": "origin",
           "notes": "MCP server request handling"
         },
         {
-          "layer": "L5",
-          "label": "Deployment Infrastructure Layer",
+          "layer": "L4",
+          "label": "Deployment & Infrastructure",
           "role": "impact",
           "notes": "Cloud instance metadata credentials retrieved"
         }
@@ -7711,14 +7717,14 @@
       ],
       "maestro_layers": [
         {
-          "layer": "L5",
-          "label": "Deployment Infrastructure Layer",
+          "layer": "L4",
+          "label": "Deployment & Infrastructure",
           "role": "origin",
           "notes": "Insecure defaults on internet-exposed deployments"
         },
         {
-          "layer": "L7",
-          "label": "Interaction and User Interface Layer",
+          "layer": "L5",
+          "label": "Evaluation & Observability",
           "role": "blind-spot",
           "notes": "Shadow deployment on corporate devices with no SOC visibility"
         }
@@ -7775,14 +7781,14 @@
       ],
       "maestro_layers": [
         {
-          "layer": "L4",
-          "label": "Tools and Integration Layer",
+          "layer": "L5",
+          "label": "Evaluation & Observability",
           "role": "blind-spot",
           "notes": "Scanning present across the ecosystem and defeated by three distinct techniques"
         },
         {
           "layer": "L1",
-          "label": "Foundation Models Layer",
+          "label": "Foundation Models",
           "role": "propagation",
           "notes": "The scanner's own LLM judge is itself a prompt-injection target"
         }
@@ -7835,22 +7841,22 @@
       ],
       "maestro_layers": [
         {
-          "layer": "L4",
-          "label": "Tools and Integration Layer",
+          "layer": "L3",
+          "label": "Agent Frameworks",
           "role": "origin",
           "notes": "Skill instructs the agent to fetch an external documentation URL"
         },
         {
-          "layer": "L4",
-          "label": "Tools and Integration Layer",
+          "layer": "L5",
+          "label": "Evaluation & Observability",
           "role": "blind-spot",
           "notes": "Published artifact contains no payload to scan"
         },
         {
-          "layer": "L3",
-          "label": "Agent Frameworks Layer",
+          "layer": "L2",
+          "label": "Data Operations",
           "role": "impact",
-          "notes": "Attacker-controlled instructions enter the agent at runtime"
+          "notes": "Attacker-controlled content enters the agent through ingestion"
         }
       ],
       "attack_vector": "Payload held off-artifact at an attacker-controlled external URL the skill tells the agent to fetch",
@@ -7901,16 +7907,16 @@
       ],
       "maestro_layers": [
         {
-          "layer": "L4",
-          "label": "Tools and Integration Layer",
+          "layer": "L3",
+          "label": "Agent Frameworks",
           "role": "origin",
           "notes": "One in eight live skills depends on an external instruction source"
         },
         {
-          "layer": "L3",
-          "label": "Agent Frameworks Layer",
+          "layer": "L2",
+          "label": "Data Operations",
           "role": "impact",
-          "notes": "6.7M installs exposed to content the publisher does not control"
+          "notes": "6.7M installs ingest content the publisher does not control"
         }
       ],
       "attack_vector": "Skills depending on external instruction sources that a third party can change after publication",
@@ -7961,14 +7967,14 @@
       ],
       "maestro_layers": [
         {
-          "layer": "L4",
-          "label": "Tools and Integration Layer",
+          "layer": "L3",
+          "label": "Agent Frameworks",
           "role": "origin",
           "notes": "Skill dependencies resolve to identifiers anyone can claim"
         },
         {
-          "layer": "L4",
-          "label": "Tools and Integration Layer",
+          "layer": "L7",
+          "label": "Agent Ecosystem",
           "role": "propagation",
           "notes": "A single re-registration inherits every installed instance"
         }

--- a/docs/frameworks-registry.js
+++ b/docs/frameworks-registry.js
@@ -4653,7 +4653,7 @@ window.CROSSWALK_FRAMEWORKS = [
     "controls": [
       {
         "control_id": "L1",
-        "title": "Foundation Models Layer",
+        "title": "Foundation Models",
         "description": "Base model layer — covers model selection, provenance, fine-tuning security, and model integrity threats.",
         "parent": null,
         "function": "Architecture Layer",
@@ -4685,7 +4685,7 @@ window.CROSSWALK_FRAMEWORKS = [
       },
       {
         "control_id": "L2",
-        "title": "Data Operations Layer",
+        "title": "Data Operations",
         "description": "Data pipelines — covers RAG, vector stores, training data, embedding security, and data governance.",
         "parent": null,
         "function": "Architecture Layer",
@@ -4717,7 +4717,7 @@ window.CROSSWALK_FRAMEWORKS = [
       },
       {
         "control_id": "L3",
-        "title": "Agent Frameworks Layer",
+        "title": "Agent Frameworks",
         "description": "Agent runtime — covers agent orchestration, goal management, memory, and planning security.",
         "parent": null,
         "function": "Architecture Layer",
@@ -4749,7 +4749,7 @@ window.CROSSWALK_FRAMEWORKS = [
       },
       {
         "control_id": "L4",
-        "title": "Tools and Integration Layer",
+        "title": "Deployment & Infrastructure",
         "description": "Tool access — covers MCP, API integrations, plugin security, and tool authorization.",
         "parent": null,
         "function": "Architecture Layer",
@@ -4781,7 +4781,7 @@ window.CROSSWALK_FRAMEWORKS = [
       },
       {
         "control_id": "L5",
-        "title": "Deployment Infrastructure Layer",
+        "title": "Evaluation & Observability",
         "description": "Infrastructure — covers containerization, networking, secrets management, and runtime isolation.",
         "parent": null,
         "function": "Architecture Layer",
@@ -4813,7 +4813,7 @@ window.CROSSWALK_FRAMEWORKS = [
       },
       {
         "control_id": "L6",
-        "title": "Orchestration Layer",
+        "title": "Security & Compliance",
         "description": "Multi-agent coordination — covers inter-agent communication, delegation, consensus, and cascading failure prevention.",
         "parent": null,
         "function": "Architecture Layer",
@@ -4845,7 +4845,7 @@ window.CROSSWALK_FRAMEWORKS = [
       },
       {
         "control_id": "L7",
-        "title": "Interaction and User Interface Layer",
+        "title": "Agent Ecosystem",
         "description": "Human-agent interface — covers user authentication, output validation, human oversight, and trust management.",
         "parent": null,
         "function": "Architecture Layer",

--- a/docs/incidents.js
+++ b/docs/incidents.js
@@ -2627,7 +2627,7 @@ window.CROSSWALK_INCIDENTS = [
     "maestro_layers": [
       {
         "layer": "L7",
-        "label": "Multi-Agent Ecosystem",
+        "label": "Agent Ecosystem",
         "role": "origin",
         "notes": "Multi-agent ecosystem with no inter-agent consistency validation"
       },
@@ -3029,7 +3029,7 @@ window.CROSSWALK_INCIDENTS = [
       },
       {
         "layer": "L7",
-        "label": "Ecosystem",
+        "label": "Agent Ecosystem",
         "role": "impact",
         "notes": "Self-replication attempts threaten agent ecosystem integrity"
       }
@@ -6914,22 +6914,22 @@ window.CROSSWALK_INCIDENTS = [
     ],
     "maestro_layers": [
       {
-        "layer": "L4",
-        "label": "Tools and Integration Layer",
+        "layer": "L7",
+        "label": "Agent Ecosystem",
         "role": "origin",
-        "notes": "Skill registry used as the distribution channel"
+        "notes": "Registry-scale campaign across the skill ecosystem"
       },
       {
         "layer": "L3",
-        "label": "Agent Frameworks Layer",
+        "label": "Agent Frameworks",
         "role": "propagation",
         "notes": "Instructions written into MEMORY.md and SOUL.md persist across sessions"
       },
       {
-        "layer": "L5",
-        "label": "Deployment Infrastructure Layer",
+        "layer": "L6",
+        "label": "Security & Compliance",
         "role": "impact",
-        "notes": "Credential, wallet and .env exfiltration to a single C2 IP"
+        "notes": "Exchange keys, wallet keys, SSH credentials and .env files exfiltrated to a single C2 IP"
       }
     ],
     "attack_vector": "Registry publisher accounts used to distribute skills that exfiltrate credentials and write persistent instructions into agent identity files",
@@ -6963,7 +6963,7 @@ window.CROSSWALK_INCIDENTS = [
     "control_failures": [
       {
         "framework": "MAESTRO",
-        "control_id": "L3.2",
+        "control_id": "L3",
         "outcome": "absent",
         "basis": "Skills also write malicious instructions directly into MEMORY.md and SOUL.md for session-persistent backdooring.",
         "source_url": "https://owasp.org/www-project-agentic-skills-top-10/",
@@ -7003,14 +7003,14 @@ window.CROSSWALK_INCIDENTS = [
     ],
     "maestro_layers": [
       {
-        "layer": "L4",
-        "label": "Tools and Integration Layer",
+        "layer": "L3",
+        "label": "Agent Frameworks",
         "role": "origin",
         "notes": "Skill manifest carries the instruction"
       },
       {
-        "layer": "L5",
-        "label": "Deployment Infrastructure Layer",
+        "layer": "L6",
+        "label": "Security & Compliance",
         "role": "impact",
         "notes": "SSH private key exfiltration"
       }
@@ -7063,16 +7063,16 @@ window.CROSSWALK_INCIDENTS = [
     ],
     "maestro_layers": [
       {
-        "layer": "L4",
-        "label": "Tools and Integration Layer",
+        "layer": "L3",
+        "label": "Agent Frameworks",
         "role": "origin",
         "notes": "Published skills cleared by registry checks"
       },
       {
-        "layer": "L7",
-        "label": "Interaction and User Interface Layer",
+        "layer": "L5",
+        "label": "Evaluation & Observability",
         "role": "blind-spot",
-        "notes": "Detection came from behaviour at runtime, not from review at publication"
+        "notes": "Detection came from runtime behaviour, not from review at publication"
       }
     ],
     "attack_vector": "Malicious skills published to a registry and installed by users before any behavioural signal surfaced",
@@ -7122,14 +7122,14 @@ window.CROSSWALK_INCIDENTS = [
     ],
     "maestro_layers": [
       {
-        "layer": "L4",
-        "label": "Tools and Integration Layer",
+        "layer": "L7",
+        "label": "Agent Ecosystem",
         "role": "origin",
         "notes": "Ecosystem-wide flaw density in published skills"
       },
       {
-        "layer": "L7",
-        "label": "Interaction and User Interface Layer",
+        "layer": "L5",
+        "label": "Evaluation & Observability",
         "role": "blind-spot",
         "notes": "8 confirmed-malicious skills still live at publication"
       }
@@ -7181,16 +7181,16 @@ window.CROSSWALK_INCIDENTS = [
     ],
     "maestro_layers": [
       {
-        "layer": "L4",
-        "label": "Tools and Integration Layer",
+        "layer": "L3",
+        "label": "Agent Frameworks",
         "role": "origin",
-        "notes": "Skills request more permission than their function needs"
+        "notes": "Skills declare more permission than their function needs"
       },
       {
-        "layer": "L5",
-        "label": "Deployment Infrastructure Layer",
+        "layer": "L6",
+        "label": "Security & Compliance",
         "role": "impact",
-        "notes": "API key and PII exposure"
+        "notes": "API key and PII exposure through the granted scope"
       }
     ],
     "attack_vector": "Over-broad skill permissions turn ordinary skill execution into credential and PII disclosure",
@@ -7240,14 +7240,14 @@ window.CROSSWALK_INCIDENTS = [
     ],
     "maestro_layers": [
       {
-        "layer": "L4",
-        "label": "Tools and Integration Layer",
+        "layer": "L3",
+        "label": "Agent Frameworks",
         "role": "origin",
         "notes": "Registry listing metadata impersonates a known brand"
       },
       {
         "layer": "L7",
-        "label": "Interaction and User Interface Layer",
+        "label": "Agent Ecosystem",
         "role": "impact",
         "notes": "User trust decision made on false metadata"
       }
@@ -7300,8 +7300,8 @@ window.CROSSWALK_INCIDENTS = [
     ],
     "maestro_layers": [
       {
-        "layer": "L4",
-        "label": "Tools and Integration Layer",
+        "layer": "L5",
+        "label": "Evaluation & Observability",
         "role": "blind-spot",
         "notes": "Signature scanning has no signature to match on instruction payloads"
       }
@@ -7352,14 +7352,20 @@ window.CROSSWALK_INCIDENTS = [
     ],
     "maestro_layers": [
       {
-        "layer": "L5",
-        "label": "Deployment Infrastructure Layer",
+        "layer": "L4",
+        "label": "Deployment & Infrastructure",
         "role": "origin",
-        "notes": "Unauthenticated WebSocket writes reach the log file"
+        "notes": "Unauthenticated WebSocket writes reach the host log file"
+      },
+      {
+        "layer": "L5",
+        "label": "Evaluation & Observability",
+        "role": "propagation",
+        "notes": "The diagnostic log becomes the injection channel"
       },
       {
         "layer": "L3",
-        "label": "Agent Frameworks Layer",
+        "label": "Agent Frameworks",
         "role": "impact",
         "notes": "Agent reads its own logs and acts on injected text"
       }
@@ -7413,22 +7419,22 @@ window.CROSSWALK_INCIDENTS = [
     ],
     "maestro_layers": [
       {
-        "layer": "L4",
-        "label": "Tools and Integration Layer",
+        "layer": "L3",
+        "label": "Agent Frameworks",
         "role": "origin",
-        "notes": "Repository-controlled configuration files"
+        "notes": "Repository-controlled configuration consumed at project open"
       },
       {
-        "layer": "L7",
-        "label": "Interaction and User Interface Layer",
+        "layer": "L6",
+        "label": "Security & Compliance",
         "role": "blind-spot",
         "notes": "Execution precedes the trust dialog meant to gate it"
       },
       {
-        "layer": "L5",
-        "label": "Deployment Infrastructure Layer",
+        "layer": "L4",
+        "label": "Deployment & Infrastructure",
         "role": "impact",
-        "notes": "Arbitrary shell execution and API key exfiltration"
+        "notes": "Arbitrary shell execution and API key exfiltration on the host"
       }
     ],
     "attack_vector": "Repository configuration files executed at project open time, ahead of the user consent prompt",
@@ -7462,7 +7468,7 @@ window.CROSSWALK_INCIDENTS = [
     "control_failures": [
       {
         "framework": "MAESTRO",
-        "control_id": "L7.2",
+        "control_id": "L6",
         "outcome": "present-but-bypassed",
         "basis": "Repository-controlled configuration files can silently execute arbitrary shell commands and exfiltrate API keys at project open time, before any trust dialog.",
         "source_url": "https://owasp.org/www-project-agentic-skills-top-10/",
@@ -7500,20 +7506,20 @@ window.CROSSWALK_INCIDENTS = [
     ],
     "maestro_layers": [
       {
-        "layer": "L5",
-        "label": "Deployment Infrastructure Layer",
+        "layer": "L4",
+        "label": "Deployment & Infrastructure",
         "role": "origin",
         "notes": "Unrate-limited localhost WebSocket reachable from the browser"
       },
       {
         "layer": "L6",
-        "label": "Orchestration Layer",
+        "label": "Security & Compliance",
         "role": "propagation",
         "notes": "Device registration without a user prompt"
       },
       {
-        "layer": "L4",
-        "label": "Tools and Integration Layer",
+        "layer": "L7",
+        "label": "Agent Ecosystem",
         "role": "impact",
         "notes": "Exfiltration through the agent's existing integrations"
       }
@@ -7549,7 +7555,7 @@ window.CROSSWALK_INCIDENTS = [
     "control_failures": [
       {
         "framework": "MAESTRO",
-        "control_id": "L7.2",
+        "control_id": "L6",
         "outcome": "absent",
         "basis": "Malicious websites can brute-force localhost WebSocket connections with no rate limiting to silently hijack local OpenClaw instances, register new devices without user prompts.",
         "source_url": "https://owasp.org/www-project-agentic-skills-top-10/",
@@ -7588,14 +7594,14 @@ window.CROSSWALK_INCIDENTS = [
     ],
     "maestro_layers": [
       {
-        "layer": "L5",
-        "label": "Deployment Infrastructure Layer",
+        "layer": "L4",
+        "label": "Deployment & Infrastructure",
         "role": "origin",
         "notes": "Commodity infostealer on the host"
       },
       {
         "layer": "L3",
-        "label": "Agent Frameworks Layer",
+        "label": "Agent Frameworks",
         "role": "impact",
         "notes": "Agent identity and memory files exfiltrated"
       }
@@ -7649,14 +7655,14 @@ window.CROSSWALK_INCIDENTS = [
     ],
     "maestro_layers": [
       {
-        "layer": "L4",
-        "label": "Tools and Integration Layer",
+        "layer": "L3",
+        "label": "Agent Frameworks",
         "role": "origin",
         "notes": "MCP server request handling"
       },
       {
-        "layer": "L5",
-        "label": "Deployment Infrastructure Layer",
+        "layer": "L4",
+        "label": "Deployment & Infrastructure",
         "role": "impact",
         "notes": "Cloud instance metadata credentials retrieved"
       }
@@ -7710,14 +7716,14 @@ window.CROSSWALK_INCIDENTS = [
     ],
     "maestro_layers": [
       {
-        "layer": "L5",
-        "label": "Deployment Infrastructure Layer",
+        "layer": "L4",
+        "label": "Deployment & Infrastructure",
         "role": "origin",
         "notes": "Insecure defaults on internet-exposed deployments"
       },
       {
-        "layer": "L7",
-        "label": "Interaction and User Interface Layer",
+        "layer": "L5",
+        "label": "Evaluation & Observability",
         "role": "blind-spot",
         "notes": "Shadow deployment on corporate devices with no SOC visibility"
       }
@@ -7774,14 +7780,14 @@ window.CROSSWALK_INCIDENTS = [
     ],
     "maestro_layers": [
       {
-        "layer": "L4",
-        "label": "Tools and Integration Layer",
+        "layer": "L5",
+        "label": "Evaluation & Observability",
         "role": "blind-spot",
         "notes": "Scanning present across the ecosystem and defeated by three distinct techniques"
       },
       {
         "layer": "L1",
-        "label": "Foundation Models Layer",
+        "label": "Foundation Models",
         "role": "propagation",
         "notes": "The scanner's own LLM judge is itself a prompt-injection target"
       }
@@ -7834,22 +7840,22 @@ window.CROSSWALK_INCIDENTS = [
     ],
     "maestro_layers": [
       {
-        "layer": "L4",
-        "label": "Tools and Integration Layer",
+        "layer": "L3",
+        "label": "Agent Frameworks",
         "role": "origin",
         "notes": "Skill instructs the agent to fetch an external documentation URL"
       },
       {
-        "layer": "L4",
-        "label": "Tools and Integration Layer",
+        "layer": "L5",
+        "label": "Evaluation & Observability",
         "role": "blind-spot",
         "notes": "Published artifact contains no payload to scan"
       },
       {
-        "layer": "L3",
-        "label": "Agent Frameworks Layer",
+        "layer": "L2",
+        "label": "Data Operations",
         "role": "impact",
-        "notes": "Attacker-controlled instructions enter the agent at runtime"
+        "notes": "Attacker-controlled content enters the agent through ingestion"
       }
     ],
     "attack_vector": "Payload held off-artifact at an attacker-controlled external URL the skill tells the agent to fetch",
@@ -7900,16 +7906,16 @@ window.CROSSWALK_INCIDENTS = [
     ],
     "maestro_layers": [
       {
-        "layer": "L4",
-        "label": "Tools and Integration Layer",
+        "layer": "L3",
+        "label": "Agent Frameworks",
         "role": "origin",
         "notes": "One in eight live skills depends on an external instruction source"
       },
       {
-        "layer": "L3",
-        "label": "Agent Frameworks Layer",
+        "layer": "L2",
+        "label": "Data Operations",
         "role": "impact",
-        "notes": "6.7M installs exposed to content the publisher does not control"
+        "notes": "6.7M installs ingest content the publisher does not control"
       }
     ],
     "attack_vector": "Skills depending on external instruction sources that a third party can change after publication",
@@ -7960,14 +7966,14 @@ window.CROSSWALK_INCIDENTS = [
     ],
     "maestro_layers": [
       {
-        "layer": "L4",
-        "label": "Tools and Integration Layer",
+        "layer": "L3",
+        "label": "Agent Frameworks",
         "role": "origin",
         "notes": "Skill dependencies resolve to identifiers anyone can claim"
       },
       {
-        "layer": "L4",
-        "label": "Tools and Integration Layer",
+        "layer": "L7",
+        "label": "Agent Ecosystem",
         "role": "propagation",
         "notes": "A single re-registration inherits every installed instance"
       }

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -744,6 +744,69 @@ function collectMappingFiles(targetFile) {
   return files;
 }
 
+// ─── MAESTRO layer-name guard ─────────────────────────────────────────
+
+/**
+ * 19. The seven MAESTRO layer ids must mean the same thing everywhere.
+ *
+ * `data/frameworks/maestro.json` once named L4/L5/L7 "Tools and Integration",
+ * "Deployment Infrastructure" and "Interaction and User Interface", while the
+ * three MAESTRO mapping files named the same ids "Deployment & Infrastructure",
+ * "Evaluation & Observability" and "Agent Ecosystem". Same ids, different
+ * meanings — so a mapping row and a registry lookup disagreed about which layer
+ * had been mapped, silently.
+ *
+ * The mapping file is the source of truth here: it reproduces the CSA table in
+ * full, it is what a reader sees, and it is what the OWASP AST10 project's own
+ * MAESTRO mapping agrees with. This checks the registry and every incident
+ * record against it.
+ */
+function checkMaestroLayers() {
+  const mdPath = path.join(ROOT, 'llm-top10', 'LLM_MAESTRO.md');
+  const regPath = path.join(ROOT, 'data', 'frameworks', 'maestro.json');
+  if (!fs.existsSync(mdPath) || !fs.existsSync(regPath)) return true;
+
+  // The architecture table: | <name> | L<n> | ... |
+  const canon = {};
+  for (const line of fs.readFileSync(mdPath, 'utf8').split('\n')) {
+    const m = line.match(/^\|\s*([^|]+?)\s*\|\s*(L[1-7])\s*\|/);
+    if (m) canon[m[2]] = m[1].trim();
+  }
+  if (Object.keys(canon).length !== 7) {
+    warn('MAESTRO layers', `Could not read all seven layers from LLM_MAESTRO.md (found ${Object.keys(canon).length})`);
+    return true;
+  }
+
+  let bad = 0;
+  for (const c of JSON.parse(fs.readFileSync(regPath, 'utf8')).controls || []) {
+    if (canon[c.control_id] && c.title !== canon[c.control_id]) {
+      fail('MAESTRO layers',
+        `maestro.json ${c.control_id} is "${c.title}", but LLM_MAESTRO.md calls it "${canon[c.control_id]}"`);
+      bad++;
+    }
+  }
+
+  const incPath = path.join(ROOT, 'data', 'incidents.json');
+  if (fs.existsSync(incPath)) {
+    const doc = JSON.parse(fs.readFileSync(incPath, 'utf8'));
+    const offenders = new Map();
+    for (const inc of doc.incidents || []) {
+      for (const l of inc.maestro_layers || []) {
+        if (l.label && canon[l.layer] && l.label !== canon[l.layer]) {
+          offenders.set(`${l.layer} "${l.label}"`, (offenders.get(`${l.layer} "${l.label}"`) || 0) + 1);
+        }
+      }
+    }
+    for (const [k, n] of offenders) {
+      fail('MAESTRO layers', `incidents.json labels ${k} on ${n} record(s) — not the canonical name`);
+      bad++;
+    }
+  }
+
+  if (!bad) pass('MAESTRO layers', 'Registry and incident labels match all seven canonical layer names');
+  return bad === 0;
+}
+
 function run() {
   const args       = process.argv.slice(2);
   const quickMode  = args.includes('--quick');
@@ -792,6 +855,7 @@ function run() {
     checkDensity();
     checkCrossRefFrameworks();
     checkFrameworkVersions();
+    checkMaestroLayers();
   }
 
   // Encoding guard — mapping files plus the shared/root markdown they link to


### PR DESCRIPTION
## The problem

`data/frameworks/maestro.json` cites the CSA MAESTRO framework, but names three of the seven layers something else entirely:

| id | Registry said | CSA, `LLM_MAESTRO.md`, `Agentic_MAESTRO.md`, `DSGAI_MAESTRO.md`, and OWASP AST10 all say |
|---|---|---|
| L4 | Tools and Integration Layer | **Deployment & Infrastructure** |
| L5 | Deployment Infrastructure Layer | **Evaluation & Observability** |
| L6 | Orchestration Layer | **Security & Compliance** |
| L7 | Interaction and User Interface Layer | **Agent Ecosystem** |

Same seven ids, two different meanings. A mapping row saying `L5` and a registry lookup returning `L5` were talking about different layers, and nothing in the project said so.

Found while preparing T-A10-03: the AST10 project publishes its own per-risk MAESTRO mapping, and its layer names matched our Markdown but not our registry.

## What this changes

**1. The registry.** All seven titles corrected to the CSA names. **No mapping row is affected** — all 3,211 reference only the top-level ids `L1`–`L7`, never a sub-control.

**2. The 17 AST10 incident records from #29.** I assigned those under the registry's wrong semantics — my error in that PR. Credential exfiltration sat on `L5` "Deployment Infrastructure" where CSA puts *observability*; the skill registry sat on `L4` where CSA puts *servers and networks*. Each of the 17 is re-derived against the CSA definitions and cross-checked against AST10's published per-risk layer mapping (e.g. ClawHavoc → AST01 → layers 7, 3, 6 — which is what the record now carries). Two stray labels in older records are normalised in passing.

**3. The three drafted `control_failures`.** Retargeted from sub-controls (`L3.2`, `L7.2`) to top-level layer ids. The sub-controls follow the same superseded model and their placement is an open question (**#31**), so nothing new should depend on them.

**4. A guard.** `checkMaestroLayers()` reads the architecture table out of `llm-top10/LLM_MAESTRO.md` and requires the registry's seven titles *and every incident label* to match it. The Markdown is the source of truth: it reproduces the CSA table in full and it is what a reader actually sees.

## Verification

- Negative test: reinstating the old `L7` title → `✗ maestro.json L7 is "Interaction and User Interface Layer", but LLM_MAESTRO.md calls it "Agent Ecosystem"`, validation FAILED. Restored → 0 errors, 284 passed.
- `validate.js` 0 errors / 69 warnings / **284** passed (was 283 — this check is the new one)
- `stats:check` green · `markdownlint` 0 errors · `test:scripts` 3 pass · `audit:incidents` 131 incidents, 3 control failures, 0 without a basis
- Post-fix label sweep: **0** non-canonical labels across all 131 records

## Not in scope

The 21 registry **sub-controls** were written against the same mistaken model and several now sit under a layer that no longer describes them. Re-homing them changes control ids, which is taxonomy work rather than transcription — filed as **#31** for a maintainer decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)